### PR TITLE
fix the pagination parameters

### DIFF
--- a/src/trpc/client/chats.ts
+++ b/src/trpc/client/chats.ts
@@ -14,14 +14,14 @@ const getChatByChatId = async (chatId: string): Promise<chats.Chat | null> => {
 const getChatsByUserId = async (
     userId: string,
     updatedAfter?: number,
-    limit: number = 20,
-    offset: number = 0
+    page: number = 0,
+    limit: number = 20
 ): Promise<PaginatedResult<chats.Chat>> => {
     return await (client as any).chats.getChatsByUserId.query({
         userId,
         updatedAfter,
-        limit,
-        offset
+        page,
+        limit
     });
 };
 
@@ -32,28 +32,28 @@ const deleteChat = async (chatId: string): Promise<void> => {
 const getMessagesByChatId = async (
     chatId: string,
     createdAfter?: number,
-    limit: number = 20,
-    offset: number = 0
+    page: number = 0,
+    limit: number = 20
 ): Promise<PaginatedResult<chats.Message>> => {
     return await (client as any).chats.getMessagesByChatId.query({
         chatId,
         createdAfter,
-        limit,
-        offset
+        page,
+        limit
     });
 };
 
 const getMessagesByUserId = async (
     userId: string,
     createdAfter?: number,
-    limit: number = 20,
-    offset: number = 0
+    page: number = 0,
+    limit: number = 20
 ): Promise<PaginatedResult<chats.Message>> => {
     return await (client as any).chats.getMessagesByUserId.query({
         userId,
         createdAfter,
-        limit,
-        offset
+        page,
+        limit
     });
 };
 


### PR DESCRIPTION
This pull request refactors pagination parameters in the `src/trpc/client/chats.ts` file to improve consistency and align with a page-based pagination approach. The changes replace `limit` and `offset` parameters with `page` and `limit` parameters in several functions.

### Pagination refactor:

* [`getChatsByUserId`](diffhunk://#diff-8f96142e7fea0aa397a1993bdffde4da1679a01878832ec5560be299348f56d6L17-R24): Replaced `limit` and `offset` with `page` and `limit` to adopt a page-based pagination system.
* [`getMessagesByChatId`](diffhunk://#diff-8f96142e7fea0aa397a1993bdffde4da1679a01878832ec5560be299348f56d6L35-R56): Updated to use `page` and `limit` instead of `limit` and `offset` for pagination.
* [`getMessagesByUserId`](diffhunk://#diff-8f96142e7fea0aa397a1993bdffde4da1679a01878832ec5560be299348f56d6L35-R56): Modified to use `page` and `limit` parameters, replacing `limit` and `offset`.