### PR TITLE
publish ConnectionDeletionEvent on connection deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessenger",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A TypeScript library for trpc client and routes",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/models/events.ts
+++ b/src/models/events.ts
@@ -40,11 +40,16 @@ interface ConnectionRequestEvent extends BaseEvent {
     connectionRequest: connection.ConnectionRequest;
 };
 
+interface ConnectionDeletionEvent extends BaseEvent {
+    type: 'connectionDeletion';
+    connectionId: number;
+};
+
 export {
     BaseEventSchema,
-    // MessageEventSchema,
     BaseEvent,
     ChatMessageEvent,
     ChatDeletionEvent,
-    ConnectionRequestEvent
+    ConnectionRequestEvent,
+    ConnectionDeletionEvent
 };

--- a/src/trpc/server/routes/connections.ts
+++ b/src/trpc/server/routes/connections.ts
@@ -170,12 +170,12 @@ const deleteConnection = trpc.procedure
             if (chat) {
                 await deleteChat(chat.chatId);
             }
-            const connectionDeleteionEvent: ConnectionDeletionEvent = {
+            const connectionDeletionEvent: ConnectionDeletionEvent = {
                 type: 'connectionDeletion',
                 userIds: [connection.userId1, connection.userId2],
                 connectionId: input.connectionId,
             };
-            await publishEvent(connectionDeleteionEvent);
+            await publishEvent(connectionDeletionEvent);
         } catch (error) {
             console.error(`❌ Error deleting connection:`, error);
             throw new Error('Failed to delete connection');


### PR DESCRIPTION
This pull request introduces a new `ConnectionDeletionEvent` to the event system, updates the `deleteConnection` procedure to emit this event, and includes a minor version bump in the `package.json` file. These changes enhance the functionality for handling connection deletions and ensure proper event publishing.

### Event System Enhancements:

* Added a new `ConnectionDeletionEvent` interface to the event model, which includes the event type, associated connection ID, and user IDs. (`src/models/events.ts`, [src/models/events.tsR43-R54](diffhunk://#diff-29f0de29b652d12d7619fdf1e8bb92886aed8bb019cfdf1f439fee3133310e4aR43-R54))
* Updated imports in `src/trpc/server/routes/connections.ts` to include the newly added `ConnectionDeletionEvent`.

### Connection Deletion Improvements:

* Modified the `deleteConnection` procedure to:
  - Validate the connection's existence before deletion.
  - Publish a `ConnectionDeletionEvent` after successfully deleting the connection and its associated chat. (`src/trpc/server/routes/connections.ts`, [src/trpc/server/routes/connections.tsR164-R178](diffhunk://#diff-d0bdd5a68fdf4575fb9dfa52ef40750750d29a73e6145a6158ce373331c813cdR164-R178))

### Version Update:

* Bumped the library version from `0.3.0` to `0.3.1` in `package.json` to reflect the added functionality. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))