### PR TITLE
renamed getEventByProviderOrCustomerId to getEventsByProviderOrCustomerId

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessenger",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A TypeScript library for trpc client and routes",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {

--- a/src/trpc/server/routes/schedule.ts
+++ b/src/trpc/server/routes/schedule.ts
@@ -30,7 +30,7 @@ const getEventsByCustomerId = trpc.procedure
         return await getEventsByCustomer(input.customerId);
     });
 
-const getEventByProviderOrCustomerId = trpc.procedure
+const getEventsByProviderOrCustomerId = trpc.procedure
     .input(z.object({ userId: z.string() }))
     .query(async ({ input }): Promise<any> => {
         return await getEventsByProviderOrCustomer(input.userId);
@@ -108,7 +108,7 @@ const scheduleRouter = trpc.router({
     getEventById,
     getEventsByProviderId,
     getEventsByCustomerId,
-    getEventByProviderOrCustomerId,
+    getEventsByProviderOrCustomerId,
     createEvent,
     updateEventStatus,
     deleteEvent


### PR DESCRIPTION
This pull request includes a minor update to the `schedule` router in the `src/trpc/server/routes/schedule.ts` file. The change standardizes the naming convention for a procedure and its corresponding router entry.

### Naming consistency updates:
* Renamed the procedure `getEventByProviderOrCustomerId` to `getEventsByProviderOrCustomerId` to align with plural naming conventions.
* Updated the `scheduleRouter` to reflect the renamed procedure, ensuring consistency across the router and procedure definitions.