### PR TITLE
add update status api, but color and customerid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@innobridge/trpcmessenger",
-  "version": "0.4.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@innobridge/trpcmessenger",
-      "version": "0.4.1",
+      "version": "0.5.2",
       "license": "InnoBridge",
       "dependencies": {
         "@innobridge/qatar": "^1.1.0",
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "@innobridge/lexi": "^0.0.3",
-        "@innobridge/scheduler": "^0.0.4",
+        "@innobridge/scheduler": "^0.0.5",
         "@innobridge/usermanagement": "^0.2.1"
       }
     },
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@innobridge/scheduler": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@innobridge/scheduler/-/scheduler-0.0.4.tgz",
-      "integrity": "sha512-i0dtZk2jKteswVkg+RAAef+81v86nOsR2TOPoLmyxyU5jmRNpBflfUA5ZQ4rlQVb9UgS900HhiojUvLhA7LyOQ==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@innobridge/scheduler/-/scheduler-0.0.5.tgz",
+      "integrity": "sha512-Ja1fA5Q7UYEPjRjpBJSbQE7XHnQD89BlZBwYPFrVbfgKKPE5cIi6u7puFvbQL/cnbCg+kjaSBUqm5Jnqsb3/wg==",
       "license": "InnoBridge",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessenger",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A TypeScript library for trpc client and routes",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@innobridge/lexi": "^0.0.3",
-    "@innobridge/scheduler": "^0.0.4",
+    "@innobridge/scheduler": "^0.0.5",
     "@innobridge/usermanagement": "^0.2.1"
   }
 }

--- a/src/trpc/client/schedule.ts
+++ b/src/trpc/client/schedule.ts
@@ -1,5 +1,6 @@
 import { client } from '@/trpc/client/api';
 import { events } from '@innobridge/scheduler';
+import e from 'express';
 
 const getEventById = async (eventId: string): Promise<events.Event | null> => {
     return await (client as any).schedule.getEventById.query({ eventId });
@@ -21,8 +22,20 @@ const createEvent = async (event: events.Event): Promise<events.Event> => {
     return await (client as any).schedule.createEvent.mutate(event);
 };
 
-const updateEventStatus = async (eventId: string, status: events.EventStatus, customerId?: string, color?: string): Promise<events.Event> => {
-    return await (client as any).schedule.updateEventStatus.mutate({ eventId, status, customerId, color });
+const updateEventStatus = async (eventId: string, status: events.EventStatus): Promise<events.Event> => {
+    return await (client as any).schedule.updateEventStatus.mutate({ eventId, status });
+};
+
+const updateEventStatusAndColor = async (eventId: string, status: events.EventStatus, color: string): Promise<events.Event> => {
+    return await (client as any).schedule.updateEventStatusAndColor.mutate({ eventId, status, color });
+};
+
+const updateEventStatusAndCustomerId = async (eventId: string, status: events.EventStatus, customerId: string): Promise<events.Event> => {
+    return await (client as any).schedule.updateEventStatusAndCustomerId.mutate({ eventId, status, customerId });
+};
+
+const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: events.EventStatus, color: string, customerId: string): Promise<events.Event> => {
+    return await (client as any).schedule.updateEventStatusWithColorAndCustomerId.mutate({ eventId, status, color, customerId });
 };
 
 const deleteEvent = async (eventId: string): Promise<void> => {
@@ -50,6 +63,9 @@ export {
     getEventsByProviderOrCustomerId,
     createEvent,
     updateEventStatus,
+    updateEventStatusAndColor,
+    updateEventStatusAndCustomerId,
+    updateEventStatusWithColorAndCustomerId,
     deleteEvent,
     bindSubscriberToSchedule,
     unbindSubscriberToSchedule

--- a/src/trpc/client/schedule.ts
+++ b/src/trpc/client/schedule.ts
@@ -1,6 +1,5 @@
 import { client } from '@/trpc/client/api';
 import { events } from '@innobridge/scheduler';
-import e from 'express';
 
 const getEventById = async (eventId: string): Promise<events.Event | null> => {
     return await (client as any).schedule.getEventById.query({ eventId });


### PR DESCRIPTION
This pull request introduces enhancements to the `@innobridge/trpcmessenger` package, focusing on extending the functionality for event status updates in the scheduling module. The changes include new methods to handle specific combinations of event attributes (status, color, and customer ID), updates to dependencies, and minor adjustments to the codebase.

### Enhancements to event status updates:

* **New methods for specific updates in the client:**
  - Added `updateEventStatusAndColor`, `updateEventStatusAndCustomerId`, and `updateEventStatusWithColorAndCustomerId` methods in `src/trpc/client/schedule.ts` to handle updates involving combinations of status, color, and customer ID. [[1]](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L24-R38) [[2]](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5R66-R68)
  
* **New procedures in the server:**
  - Added corresponding TRPC procedures (`updateEventStatusAndColor`, `updateEventStatusAndCustomerId`, and `updateEventStatusWithColorAndCustomerId`) in `src/trpc/server/routes/schedule.ts` to support these operations on the server side. These procedures include input validation and event publishing logic. [[1]](diffhunk://#diff-b8b4875c3ecc713683398db53ed54d72b2df836b2c2feb24f603780bdd9f61a0R123-R206) [[2]](diffhunk://#diff-b8b4875c3ecc713683398db53ed54d72b2df836b2c2feb24f603780bdd9f61a0R273-R275)

### Dependency updates:

* Updated the `@innobridge/scheduler` peer dependency version from `^0.0.4` to `^0.0.5` in `package.json`.

### Version bump:

* Incremented the package version from `0.5.1` to `0.5.2` in `package.json` to reflect the new changes.

These updates improve the flexibility of the scheduling module, allowing more granular updates to event attributes while maintaining compatibility with the latest `@innobridge/scheduler` package.