### PR TITLE
update customerId to string | null for update status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "peerDependencies": {
         "@innobridge/lexi": "^0.0.3",
-        "@innobridge/scheduler": "^0.0.5",
+        "@innobridge/scheduler": "^0.0.6",
         "@innobridge/usermanagement": "^0.2.1"
       }
     },
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/@innobridge/scheduler": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@innobridge/scheduler/-/scheduler-0.0.5.tgz",
-      "integrity": "sha512-Ja1fA5Q7UYEPjRjpBJSbQE7XHnQD89BlZBwYPFrVbfgKKPE5cIi6u7puFvbQL/cnbCg+kjaSBUqm5Jnqsb3/wg==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@innobridge/scheduler/-/scheduler-0.0.6.tgz",
+      "integrity": "sha512-OGlWD4mQFq0ISsHpE1jaZPQbiBKeyt5qy2Stmw+D12kL9YZclE5rWbKERbZUrwiCJ9/UnGb/1JIW80fJdhYhQA==",
       "license": "InnoBridge",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@innobridge/trpcmessenger",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A TypeScript library for trpc client and routes",
   "author": "yilengyao <innobridgetechnology@gmail.com>",
   "repository": {
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "@innobridge/lexi": "^0.0.3",
-    "@innobridge/scheduler": "^0.0.5",
+    "@innobridge/scheduler": "^0.0.6",
     "@innobridge/usermanagement": "^0.2.1"
   }
 }

--- a/src/trpc/client/schedule.ts
+++ b/src/trpc/client/schedule.ts
@@ -29,11 +29,11 @@ const updateEventStatusAndColor = async (eventId: string, status: events.EventSt
     return await (client as any).schedule.updateEventStatusAndColor.mutate({ eventId, status, color });
 };
 
-const updateEventStatusAndCustomerId = async (eventId: string, status: events.EventStatus, customerId: string): Promise<events.Event> => {
+const updateEventStatusAndCustomerId = async (eventId: string, status: events.EventStatus, customerId: string | null): Promise<events.Event> => {
     return await (client as any).schedule.updateEventStatusAndCustomerId.mutate({ eventId, status, customerId });
 };
 
-const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: events.EventStatus, color: string, customerId: string): Promise<events.Event> => {
+const updateEventStatusWithColorAndCustomerId = async (eventId: string, status: events.EventStatus, color: string, customerId: string | null): Promise<events.Event> => {
     return await (client as any).schedule.updateEventStatusWithColorAndCustomerId.mutate({ eventId, status, color, customerId });
 };
 

--- a/src/trpc/server/routes/schedule.ts
+++ b/src/trpc/server/routes/schedule.ts
@@ -150,7 +150,7 @@ const updateEventStatusAndCustomerId = trpc.procedure
     .input(z.object({
         eventId: z.string(),
         status: z.enum(['vacant', 'booked', 'fulfilled', 'cancelled']),
-        customerId: z.string()
+        customerId: z.string().nullable()
     }))
     .mutation(async ({ input }): Promise<any> => {
         try {
@@ -177,7 +177,7 @@ const updateEventStatusWithColorAndCustomerId = trpc.procedure
         eventId: z.string(),
         status: z.enum(['vacant', 'booked', 'fulfilled', 'cancelled']),
         color: z.string(),
-        customerId: z.string()
+        customerId: z.string().nullable()
     }))
     .mutation(async ({ input }): Promise<any> => {
         try {


### PR DESCRIPTION
This pull request includes updates to dependencies, versioning, and enhancements to the `customerId` handling in event-related functions. The most significant changes involve making `customerId` nullable to improve flexibility and compatibility.

### Dependency and version updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the library version from `0.5.2` to `0.5.3` and bumped the peer dependency for `@innobridge/scheduler` from `^0.0.5` to `^0.0.6`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L67-R67)

### Enhancements to `customerId` handling:
* [`src/trpc/client/schedule.ts`](diffhunk://#diff-32b5325a6e2462cfb2a1fe3f56c45039ab799a49e424cf886635472ffdbf6ca5L32-R36): Updated the `updateEventStatusAndCustomerId` and `updateEventStatusWithColorAndCustomerId` functions to allow `customerId` to be `null`.
* [`src/trpc/server/routes/schedule.ts`](diffhunk://#diff-b8b4875c3ecc713683398db53ed54d72b2df836b2c2feb24f603780bdd9f61a0L153-R153): Modified the input schemas for `updateEventStatusAndCustomerId` and `updateEventStatusWithColorAndCustomerId` to make `customerId` nullable using `.nullable()`. [[1]](diffhunk://#diff-b8b4875c3ecc713683398db53ed54d72b2df836b2c2feb24f603780bdd9f61a0L153-R153) [[2]](diffhunk://#diff-b8b4875c3ecc713683398db53ed54d72b2df836b2c2feb24f603780bdd9f61a0L180-R180)